### PR TITLE
Release lock of users on invalid PUT

### DIFF
--- a/users/main.go
+++ b/users/main.go
@@ -88,6 +88,7 @@ func (u *Users) PutUser(w rest.ResponseWriter, r *rest.Request) {
 	u.Lock()
 	if u.Store[id] == nil {
 		rest.NotFound(w, r)
+		u.Unlock()
 		return
 	}
 	user := User{}


### PR DESCRIPTION
Release lock of users storage when PUT is performed with in non-existing id
