### PR TITLE
Add forceSSL middleware README/example

### DIFF
--- a/force-ssl/README.md
+++ b/force-ssl/README.md
@@ -1,0 +1,13 @@
+# ForceSSL
+
+Demonstrate how to use the [ForceSSL Middleware](https://github.com/jadengore/go-json-rest-middleware-force-ssl) to force HTTPS on requests to a `go-json-rest` API.
+
+For the purposes of this demo, we are using HTTP for all requests and checking the `X-Forwarded-Proto` header to see if it is set to HTTPS (many routers set this to show what type of connection the client is using, such as Heroku). To do a true HTTPS test, make sure and use [`http.ListenAndServeTLS`](https://golang.org/pkg/net/http/#ListenAndServeTLS) with a valid certificate and key file.
+
+Additional documentation for the ForceSSL middleware can be found [here](https://github.com/jadengore/go-json-rest-middleware-force-ssl).
+
+curl demo:
+``` sh
+curl -i 127.0.0.1:8080/
+curl -H "X-Forwarded-Proto:https" -i 127.0.0.1:8080/
+```

--- a/force-ssl/main.go
+++ b/force-ssl/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"github.com/ant0ine/go-json-rest/rest"
+	"github.com/jadengore/go-json-rest-middleware-force-ssl"
+	"log"
+	"net/http"
+)
+
+func main() {
+	api := rest.NewApi()
+	api.Use(&forceSSL.Middleware{
+		TrustXFPHeader:     true,
+		Enable301Redirects: false,
+	})
+	api.SetApp(rest.AppSimple(func(w rest.ResponseWriter, r *rest.Request) {
+		w.WriteJson(map[string]string{"body": "Hello World!"})
+	}))
+
+	// For the purposes of this demo, only HTTP connections accepted.
+	// For true HTTPS, use ListenAndServeTLS.
+	// https://golang.org/pkg/net/http/#ListenAndServeTLS
+	log.Fatal(http.ListenAndServe(":8080", api.MakeHandler()))
+}


### PR DESCRIPTION
@ant0ine Thank you for starring my repo!

This PR adds documentation and an example consistent with the structure of this repository for `forceSSL`, a middleware I created to force HTTPS across a `go-json-rest` API's endpoints.

Let me know if I need to add any additional info!